### PR TITLE
Enable ingress

### DIFF
--- a/charts/stages/dojo.yaml
+++ b/charts/stages/dojo.yaml
@@ -12,6 +12,9 @@ environment: STAGING
 instancegroup: big-nodes
 nextPublicGqlEndpoint: http://graphql-dojo.dmp.mediajel.ninja/
 
+ingress:
+  enabled: true
+
 autoscaling:
   enabled: true
   minReplicas: 1

--- a/charts/stages/production.yaml
+++ b/charts/stages/production.yaml
@@ -13,6 +13,9 @@ environment: PRODUCTION
 instancegroup: big-nodes
 nextPublicGqlEndpoint: http://graphql.dmp.cnna.io/
 
+ingress:
+  enabled: true
+
 autoscaling:
   enabled: true
   minReplicas: 1


### PR DESCRIPTION
This pull request enables ingress for both the staging and production environments. This will allow external traffic to reach the services defined in these environments through an ingress controller.

Configuration changes:

* Enabled ingress in the `charts/stages/dojo.yaml` file for the STAGING environment.
* Enabled ingress in the `charts/stages/production.yaml` file for the PRODUCTION environment.