### PR TITLE
feat(ci): migrate production deploy to GitOps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
     parameters:
       branch:
         type: string
-        default: "main"
+        default: "master"
     steps:
       - run:
           name: Clone GitOps Repository (<< parameters.branch >>)
@@ -45,7 +45,7 @@ commands:
         type: string
       branch:
         type: string
-        default: "main"
+        default: "master"
       commit_action:
         type: string
         default: "update image tag to"
@@ -62,36 +62,6 @@ commands:
             Author: $(git log -1 --pretty=format:'%an <%ae>')"
 
             git push origin << parameters.branch >>
-  install-k8s-tools:
-    description: "Install kops, kubectl, and Helm 3"
-    steps:
-      - run:
-          name: Install kops
-          command: |
-            KOPS_VERSION=1.22.6
-            wget -O kops https://github.com/kubernetes/kops/releases/download/v${KOPS_VERSION}/kops-linux-amd64
-            chmod +x ./kops
-            sudo mv ./kops /usr/local/bin/kops
-            echo "export KOPS_CLUSTER_NAME=${KOPS_CLUSTER_NAME}" >> $BASH_ENV
-            echo "export KOPS_STATE_STORE=s3://${KOPS_STATE_STORE}" >> $BASH_ENV
-            echo "export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> $BASH_ENV
-            echo "export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> $BASH_ENV
-            echo "export AWS_REGION=${AWS_ECR_REGION}" >> $BASH_ENV
-      - run:
-          name: Install kubectl
-          command: |
-            wget -O kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-            chmod +x ./kubectl
-            sudo mv ./kubectl /usr/local/bin/kubectl
-      - run:
-          name: Install Helm 3
-          command: |
-            wget https://get.helm.sh/helm-v3.5.2-linux-amd64.tar.gz
-            tar -xf helm-v3.5.2-linux-amd64.tar.gz
-            chmod +x ./linux-amd64/helm
-            sudo mv ./linux-amd64/helm /usr/local/bin/helm3
-            kops export kubecfg --admin
-            helm3 version
 
 jobs:
   build:
@@ -131,7 +101,7 @@ jobs:
         type: string
       target_branch:
         type: string
-        default: "main"
+        default: "master"
       commit_action:
         type: string
         default: "update image tag to"
@@ -151,26 +121,6 @@ jobs:
           app_name: << parameters.app_name >>
           branch: << parameters.target_branch >>
           commit_action: << parameters.commit_action >>
-  # Helm Deploy Job Workflow
-  deploy-production:
-    executor: docker-executor
-    steps:
-      - checkout
-      - install-k8s-tools
-      - run:
-          name: Deploy Graphql Docs to Production (Helm)
-          command: |
-            kops export kubecfg --admin
-            helm3 upgrade --install gql-docs charts/ --set \
-            commitSha=${CIRCLE_SHA1} -f charts/stages/production.yaml \
-            --history-max=1 -n public-apps
-      - run:
-          name: Rollout Graphql Docs Production
-          command: |
-            kops export kubecfg --admin
-            kubectl rollout restart deployment gql-docs -n public-apps
-            kubectl rollout status deployment/gql-docs -n public-apps -w
-
 # ---------------------------------------------------------------------------
 # Workflows
 # ---------------------------------------------------------------------------
@@ -209,9 +159,15 @@ workflows:
           filters:
             branches:
               only: master
-      # Deploy
-      - deploy-production:
+      # GitOps deploy → k8s-infra master
+      - deploy:
           name: Deploy-Graphql-Docs-Production
+          app_name: mediajel-gql-docs
+          target_branch: master
+          update_script: |
+            yq eval '.spec.values.tag = env(CIRCLE_SHA1)' -i \
+              fluxcd/clusters/production/apps/mediajel-gql-docs/mediajel-gql-docs.yaml
+            git add fluxcd/clusters/production/apps/mediajel-gql-docs/mediajel-gql-docs.yaml
           context: PRODUCTION
           filters:
             branches:


### PR DESCRIPTION
Convert the production workflow from the legacy helm deploy-production job (kops+kubectl+helm3) to the parameterized deploy job:
- target_branch: master (production cluster tracks k8s-infra master)
- update .spec.values.tag in fluxcd/clusters/production/apps/mediajel-gql-docs/*
- remove deploy-production job and install-k8s-tools command
- flip target_branch/command defaults main->master Staging (dojo) workflow unchanged.